### PR TITLE
Fix issue with large diffs

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,13 +6,16 @@ import os
 import re
 import json
 import requests
-import pprint
+from pprint import pprint
 
 class MissingToken(Exception):
     '''Raised when the GitHub token is missing'''
+    
+class MissingPatchData(Exception):
+    '''Raised when the patch data is missing'''    
 
 def fetch_patch():
-    '''Grabs the patch data from the GitHub API and returns it as a JSON object.'''
+    '''Grabs the patch data from the GitHub API.'''
     git_session = requests.Session()
     headers = {
         'Accept': 'application/vnd.github+json',
@@ -27,16 +30,15 @@ def fetch_patch():
 
 def parse_patch_data(patch_data):
     '''Takes the patch data and returns a dictionary of files and the lines'''
+    line_array = []
+    sublist = []
     final_dict = {}
     for entry in patch_data:
         if entry['additions'] != 0:
+            if 'patch' in entry:
                 patch_array = re.split('\n', entry['patch'])
                 # clean patch array
                 patch_array = [i for i in patch_array if i]
-                line_array = []
-                sublist = []
-        else:
-            continue    
 
         for item in patch_array:
             # Grabs hunk annotation and strips out added lines

--- a/main.py
+++ b/main.py
@@ -34,8 +34,7 @@ def parse_patch_data(patch_data):
     sublist = []
     final_dict = {}
     for entry in patch_data:
-        if entry['additions'] != 0:
-            if 'patch' in entry:
+        if entry['additions'] != 0 and 'patch' in entry:
                 patch_array = re.split('\n', entry['patch'])
                 # clean patch array
                 patch_array = [i for i in patch_array if i]

--- a/main.py
+++ b/main.py
@@ -34,6 +34,10 @@ def parse_patch_data(patch_data):
     sublist = []
     final_dict = {}
     for entry in patch_data:
+        # We can only operate on files with additions and a patch key
+        # Some really long files don't have a patch key because github 
+        # doesn't want to return the whole file and instead retuens a 
+        # message in the PR that the file is too large to display
         if entry['additions'] != 0 and 'patch' in entry:
                 patch_array = re.split('\n', entry['patch'])
                 # clean patch array

--- a/main.py
+++ b/main.py
@@ -6,7 +6,6 @@ import os
 import re
 import json
 import requests
-from pprint import pprint
 
 class MissingToken(Exception):
     '''Raised when the GitHub token is missing'''


### PR DESCRIPTION
Fix issue with diffs that are too large to display in the PR. In these cases GitHub doesn't provide the patch, so there's no way to grab the modified lines. 

<img width="1069" alt="Screenshot 2024-02-14 at 2 55 43 PM" src="https://github.com/hestonhoffman/changed-lines/assets/21250475/a8a0f137-2161-42c9-b3fa-3250876fd8ce">


