### PR TITLE
Changing location of array declaration

### DIFF
--- a/main.py
+++ b/main.py
@@ -29,10 +29,10 @@ def fetch_patch():
 
 def parse_patch_data(patch_data):
     '''Takes the patch data and returns a dictionary of files and the lines'''
-    line_array = []
-    sublist = []
     final_dict = {}
     for entry in patch_data:
+        line_array = []
+        sublist = []
         # We don't need removed files
         if entry['status'] != 'removed':
             # We can only operate on files with additions and a patch key


### PR DESCRIPTION
Before results looked like:
{"FILEA": [53, 1399], "FILEB": [53, 1399]}
This is because line_array and sublist aren't wiped when going to the new file and the dictionary saves the array by reference (not deep-copying).

Now results look like:
{"FILEA": [53], "FILEB": [1399]}