### PR TITLE
Modified the `fetch_patch` function to handle responses with more than one page of data

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,11 +24,16 @@ def fetch_patch():
         'X-GitHub-Api-Version': '2022-11-28',
         'Authorization':f'Bearer {TOKEN}'
         }
-    git_request = git_session.get(
-        f'{api_url}/repos/{repo}/pulls/{pr}/files',
-        headers=headers
-        )
-    return git_request.json()
+    # Fetch the first page
+    response = git_session.get(
+        f"{api_url}/repos/{repo}/pulls/{pr}/files", headers=headers
+    )
+    files = response.json()
+    # Follow 'next' links to fetch the remaining pages
+    while 'next' in response.links:
+        response = git_session.get(response.links['next']['url'], headers=headers)
+        files.extend(response.json())
+    return files
 
 def parse_patch_data(patch_data):
     '''Takes the patch data and returns a dictionary of files and the lines'''


### PR DESCRIPTION
Fixes Issue #19 

Modified the `fetch_patch` function to handle responses with more than one page of data to ensure that all files modified in a PR are collected.

For more information on pagination in the GitHub REST API see:
https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2022-11-28